### PR TITLE
Fix error when writing telemetry.conf

### DIFF
--- a/telemetry.py
+++ b/telemetry.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         else:
             config.set('main', 'sample', 'false')
         if edit_config:
-            with open(args[0], 'wb') as cf:
+            with open(args[0], 'w') as cf:
                 config.write(cf)
             sys.stdout.write("Configuration file [%s] successfully changed.\n" % config_filename)
             exit(0)


### PR DESCRIPTION
Fix error from python3 when using any of the config writing flags: “Error writing to configuration file [a bytes-like object is required, not 'str']” 

[ConfigParser.write](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.write) raises this error because the “the specified file object … must be opened in text mode (accepting strings)”, but telemetry.py opens it in `wb` mode.